### PR TITLE
Gracefully handle UnicodeEncodeError on Python 2.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changes
 
 - Drop support for Python 2.6.
 
+- Gracefully handle ``UnicodeEncodeError`` that can be produced when
+  doing attribute lookup on Python 2 by instead raising a ``LocationError``.
 
 4.0.0 (2014-03-21)
 ------------------
@@ -283,4 +285,3 @@ No further changes since 3.4.0a1.
 
 Initial release as a separate project, corresponds to ``zope.traversing``
 from Zope 3.4.0a1
-

--- a/src/zope/traversing/tests/test_conveniencefunctions.py
+++ b/src/zope/traversing/tests/test_conveniencefunctions.py
@@ -118,6 +118,23 @@ class Test(PlacelessSetup, TestCase):
             self.folder, './item'
             )
 
+    def testTraverseNameUnicode(self):
+        from zope.traversing.api import traverseName
+        from zope.interface import implementer
+
+        @implementer(ITraversable)
+        class BrokenTraversable(object):
+            def traverse(self, name, furtherPath):
+                getattr(self, u'\u2019', None)
+                # The above actually works on Python 3
+                raise LocationError()
+
+        self.assertRaises(
+            LocationError,
+            traverseName,
+            BrokenTraversable(), '')
+
+
     def testGetName(self):
         from zope.traversing.api import getName
         self.assertEqual(

--- a/src/zope/traversing/tests/test_traverser.py
+++ b/src/zope/traversing/tests/test_traverser.py
@@ -271,6 +271,10 @@ class DefaultTraversableTests(unittest.TestCase):
 
         self.assertRaises(LocationError, df.traverse, 'bar', [])
 
+    def testUnicodeTraversal(self):
+        df = DefaultTraversable(object())
+        self.assertRaises(LocationError, df.traverse, u'\u2019', ())
+
 def test_suite():
     loader = unittest.TestLoader()
     suite = loader.loadTestsFromTestCase(TraverserTests)


### PR DESCRIPTION
This can be produced when doing an attribute lookup. Turn it into a LocationError (or the default value).

`zope.container.traversal.ContainerTraversable` was [doing this already](https://github.com/zopefoundation/zope.container/blob/master/src/zope/container/traversal.py#L105)
