### PR TITLE
Add Python 3.6, drop Python 3.3, 100% coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.traversing
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,4 @@ exclude_lines =
     raise NotImplementedError
     self.fail
     raise AssertionError
+    raise unittest.Skip

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ bin/
 develop-eggs/
 eggs/
 parts/
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 language: python
 sudo: false
 python:
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - pypy
-  - pypy3
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    # Force a newer PyPy on the old 'precise' CI image
+    # in order to install 'cryptography' needed for coveralls
+    # After September 2017 this should be the default and the version
+    # pin can be removed.
+    - pypy-5.6.0
+    - pypy3.5-5.8.0
 install:
-  - pip install tox-travis
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-  - tox
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,18 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.2.0 (unreleased)
-------------------
+==================
 
-- Nothing changed yet.
+- Add support for Python 3.6.
 
+- Drop support for Python 3.3.
+
+- Drop support for ``python setup.py test``.
 
 4.1.0 (2016-08-05)
-------------------
+==================
 
 - Add support for Python 3.5.
 
@@ -18,19 +22,19 @@ Changes
   doing attribute lookup on Python 2 by instead raising a ``LocationError``.
 
 4.0.0 (2014-03-21)
-------------------
+==================
 
 - Add support for Python 3.4.
 
 
 4.0.0a3 (2013-03-12)
---------------------
+====================
 
 - Add support for PyPy.
 
 
 4.0.0a2 (2013-02-21)
---------------------
+====================
 
 - Remove ``zope.container`` testing dependency to break another circular
   dependency.
@@ -44,7 +48,7 @@ Changes
 
 
 4.0.0a1 (2013-02-20)
---------------------
+====================
 
 - Replace deprecated ``zope.component.adapts`` usage with equivalent
   ``zope.component.adapter`` decorator.
@@ -60,18 +64,18 @@ Changes
 
 
 3.14.0 (2011-03-02)
--------------------
+===================
 
 - Re-release of 3.13.1 as a feature version as it introduces dependencies on
   new feature releases.
 
 3.13.1 (2010-12-14)
--------------------
+===================
 
 - Fix ZCML-related dependencies.
 
 3.13 (2010-07-09)
------------------
+=================
 
 - When a ``__parent__`` attribute is available on an object, it is
   always used for absolute URL construction, and no ILocation adapter
@@ -84,23 +88,23 @@ Changes
   ILocation adapters can also be provided.
 
 3.12.1 (2010-04-30)
--------------------
+===================
 
 - Remove use of ``zope.testing.doctestunit`` in favor of stdlib's doctest.
 
 3.12.0 (2009-12-29)
--------------------
+===================
 
 - Avoid testing dependencies on ``zope.securitypolicies`` and
   ``zope.principalregistry``.
 
 3.11.0 (2009-12-27)
--------------------
+===================
 
 - Remove testing dependency on ``zope.app.publication``.
 
 3.10.0 (2009-12-16)
--------------------
+===================
 
 - Remove stray test claiming a no longer existing dependency on
   ``zope.app.applicationcontrol``.
@@ -128,13 +132,13 @@ Changes
   ``zope.pagetemplate``.
 
 3.9.0 (2009-12-15)
-------------------
+==================
 
 - Move ``IBeforeTraverseEvent`` here from ``zope.app.publication``,
   as we already deal with publication traversal.
 
 3.8.0 (2009-09-29)
-------------------
+==================
 
 - In ``zope.traversing.api.getParent()``, try to delegate to
   ``zope.location.interfaces.ILocationInfo.getParent()``, analogous to
@@ -144,21 +148,21 @@ Changes
   to invert the package interdependency, but where it is now no longer used.
 
 3.7.2 (2009-08-29)
-------------------
+==================
 
 - Make virtual hosting tests compatible with ``zope.publisher`` 3.9.
   Redirecting to a different host requires an explicit ``trusted``
   redirect now.
 
 3.7.1 (2009-06-16)
-------------------
+==================
 
 - ``AbsoluteURL`` now implements the fact that ``__call__`` returns the same
   as ``__str__`` in a manner that it applies for subclasses, too, so they only
   have to override ``__str__`` and not both.
 
 3.7.0 (2009-05-23)
-------------------
+==================
 
 - Move the ``publicationtraverse`` module to ``zope.traversing``, removing the
   ``zope.app.publisher`` -> ``zope.app.publication`` dependency (which was a
@@ -168,7 +172,7 @@ Changes
   rather than a direct reference.
 
 3.6.0 (2009-04-06)
-------------------
+==================
 
 - Change ``configure.zcml`` not to depend on ``zope.app.component``.
 
@@ -176,14 +180,14 @@ Changes
   change from 3.5.3.
 
 3.5.4 (2009-04-06)
-------------------
+==================
 
 - Revert BBB-incompatible use of ``zope.publisher.skinnable``:  that
   change belongs in a 3.6.0 release, because it requires a BBB-incompatible
   version of ``zope.publisher``.
 
 3.5.3 (2009-03-10)
-------------------
+==================
 
 - Use applySkin from new location. zope.publisher.skinnable instead of
   zope.publisher.browser.
@@ -192,14 +196,14 @@ Changes
   recursive AbsoluteURL adapters (LP: #338101).
 
 3.5.2 (2009-02-04)
-------------------
+==================
 
 - ``RootPhysicallyLocatable`` is not the same as
   ``LocationPhysicallyLocatable`` (now in ``zope.location``).
   Fix the import and testing setups.
 
 3.5.1 (2009-02-02)
-------------------
+==================
 
 - Obsolete the ``RootPhysicallyLocatable`` adapter, which has been superseded
   by the refactored ``zope.location.traversing.LocationPhysicallyLocatable``
@@ -222,7 +226,7 @@ Changes
   of retired zope3-dev at zope.org
 
 3.5.0 (2009-01-31)
-------------------
+==================
 
 - Use zope.container instead of ``zope.app.container``.
 
@@ -231,7 +235,7 @@ Changes
 - Reduce, but not eliminate, test dependencies on ``zope.app.component``.
 
 3.5.0a4 (2008-08-01)
---------------------
+====================
 
 - Reverse dependencies between ``zope.location`` and ``zope.traversing``.
 
@@ -246,13 +250,13 @@ Changes
 
 
 3.5.0a3 (2007-12-28)
---------------------
+====================
 
 - Back out the controversial ``++skin++`` traverser for XML-RPC.
 
 
 3.5.0a2 (2007-11-28)
---------------------
+====================
 
 - Port 3.4.1a1 to trunk
 
@@ -268,26 +272,26 @@ Changes
 
 
 3.4.1 (2008-07-30)
-------------------
+==================
 
 - Fix deprecation warning caused by using an old module name for
   ``ZopeSecurityPolicy`` in ``ftesting.zcml``.
 
 
 3.4.1a1 (2007-11-13)
---------------------
+====================
 
 - Do not use unicode strings to set the application server in the virtual
   host namespace. This caused absolute_url to create unicode URL's.
 
 
 3.4.0 (2007-09-29)
-------------------
+==================
 
 No further changes since 3.4.0a1.
 
 3.4.0a1 (2007-04-22)
---------------------
+====================
 
 Initial release as a separate project, corresponds to ``zope.traversing``
 from Zope 3.4.0a1

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,21 @@
-``zope.traversing``
-===================
+=====================
+ ``zope.traversing``
+=====================
+
+.. image:: https://img.shields.io/pypi/v/zope.traversing.svg
+        :target: https://pypi.python.org/pypi/zope.traversing/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.traversing.svg
+        :target: https://pypi.org/project/zope.traversing/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.traversing.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.traversing
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.traversing/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.traversing?branch=master
+
 
 This package provides adapters for resolving object paths by traversing
 an object hierarchy.  This package also includes support for traversal

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ TESTS_REQUIRE = [
 setup(
     name='zope.traversing',
     version='4.2.0.dev0',
-    url='http://github.com/zopefoundation/zope.traversing',
+    url='https://github.com/zopefoundation/zope.traversing',
     license='ZPL 2.1',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@
 ##############################################################################
 """Setup for zope.traversing package
 """
-import os
-import sys
+
 from setuptools import setup, find_packages
 
 
@@ -31,20 +30,6 @@ long_description = (read('README.rst') +
                     '\n\n' +
                     read('CHANGES.rst'))
 
-
-def test_suite():
-    # use the zope.testrunner machinery to find all the
-    # test suites we've put under ourselves
-    from zope.testrunner.options import get_options
-    from zope.testrunner.find import find_suites
-    from unittest import TestSuite
-    here = os.path.abspath(os.path.dirname(sys.argv[0]))
-    args = sys.argv[:]
-    src = os.path.join(here, 'src')
-    defaults = ['--test-path', src]
-    options = get_options(args, defaults)
-    suites = list(find_suites(options))
-    return TestSuite(suites)
 
 TESTS_REQUIRE = [
     'zope.annotation',
@@ -60,7 +45,7 @@ TESTS_REQUIRE = [
 setup(
     name='zope.traversing',
     version='4.2.0.dev0',
-    url='http://pypi.python.org/pypi/zope.traversing',
+    url='http://github.com/zopefoundation/zope.traversing',
     license='ZPL 2.1',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
@@ -74,9 +59,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',
@@ -87,7 +72,9 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['zope'],
-    extras_require=dict(test=TESTS_REQUIRE),
+    extras_require={
+        'test': TESTS_REQUIRE,
+    },
     install_requires=[
         'setuptools',
         'six',
@@ -102,7 +89,6 @@ setup(
         'zope.security',
     ],
     tests_require=TESTS_REQUIRE,
-    test_suite='__main__.test_suite',
     include_package_data=True,
     zip_safe=False,
 )

--- a/src/zope/traversing/adapters.py
+++ b/src/zope/traversing/adapters.py
@@ -151,7 +151,4 @@ def traversePathElement(obj, name, further_path, default=_marker,
     except LocationError:
         if default is not _marker:
             return default
-        else:
-            raise
-
-    return obj
+        raise

--- a/src/zope/traversing/api.py
+++ b/src/zope/traversing/api.py
@@ -88,8 +88,7 @@ def traverse(object, path, default=_marker, request=None):
     traverser = ITraverser(object)
     if default is _marker:
         return traverser.traverse(path, request=request)
-    else:
-        return traverser.traverse(path, default=default, request=request)
+    return traverser.traverse(path, default=default, request=request)
 
 
 def traverseName(obj, name, default=_marker, traversable=None, request=None):
@@ -118,8 +117,8 @@ def traverseName(obj, name, default=_marker, traversable=None, request=None):
                                   traversable=traversable, request=request)
     if further_path:
         raise NotImplementedError('further_path returned from traverse')
-    else:
-        return obj
+
+    return obj
 
 
 def getName(obj):

--- a/src/zope/traversing/interfaces.py
+++ b/src/zope/traversing/interfaces.py
@@ -17,7 +17,8 @@
 from zope.interface import Attribute
 from zope.interface import Interface
 from zope.interface import implementer
-from zope.component.interfaces import IObjectEvent
+from zope.interface.interfaces import IObjectEvent
+from zope.interface.interfaces import ObjectEvent
 
 # BBB: Re-import symbols to their old location.
 from zope.location.interfaces import LocationError as TraversalError
@@ -180,10 +181,10 @@ class IBeforeTraverseEvent(IObjectEvent):
 
 
 @implementer(IBeforeTraverseEvent)
-class BeforeTraverseEvent(object):
+class BeforeTraverseEvent(ObjectEvent):
     """An event which gets sent on publication traverse"""
 
 
     def __init__(self, ob, request):
-        self.object = ob
+        ObjectEvent.__init__(self, ob)
         self.request = request

--- a/src/zope/traversing/publicationtraverse.py
+++ b/src/zope/traversing/publicationtraverse.py
@@ -90,10 +90,10 @@ class PublicationTraverser(object):
 
         path.reverse()
 
-        # Remove double dots
+        # Remove double dots if possible
         while '..' in path:
             l = path.index('..')
-            if l < 0 or l + 2 > len(path):
+            if l + 2 > len(path):
                 break
             del path[l:l + 2]
 

--- a/src/zope/traversing/publicationtraverse.py
+++ b/src/zope/traversing/publicationtraverse.py
@@ -92,10 +92,10 @@ class PublicationTraverser(object):
 
         # Remove double dots if possible
         while '..' in path:
-            l = path.index('..')
-            if l + 2 > len(path):
+            parent_index = path.index('..')
+            if parent_index + 2 > len(path):
                 break
-            del path[l:l + 2]
+            del path[parent_index:parent_index + 2]
 
         pop = path.pop
 

--- a/src/zope/traversing/testing.py
+++ b/src/zope/traversing/testing.py
@@ -49,7 +49,7 @@ class ContainedProxy(object):
         if name in ['__parent__', '__name__', '__obj__']:
             self.__dict__[name] = value
             return
-        setattr(self.__obj__, name, value)
+        setattr(self.__obj__, name, value) # pragma: no cover
 
     def __eq__(self, value):
         return self.__obj__ == value
@@ -63,7 +63,7 @@ def contained(obj, root, name=None):
     return obj
 
 # BBB: Kept for backward-compatibility, in case some package depends on it.
-def setUp(): #pragma: nocover
+def setUp(): # pragma: no cover
     zope.component.provideAdapter(Traverser, (None,), ITraverser)
     zope.component.provideAdapter(DefaultTraversable, (None,), ITraversable)
     zope.component.provideAdapter(LocationPhysicallyLocatable,

--- a/src/zope/traversing/tests/test_lang.py
+++ b/src/zope/traversing/tests/test_lang.py
@@ -55,10 +55,3 @@ class Test(CleanUp, unittest.TestCase):
         self.assertTrue(ob is ob2)
         self.assertTrue(request.shifted)
         self.assertEqual(["ru"], browser_languages.getPreferredLanguages())
-
-
-def test_suite():
-    return unittest.makeSuite(Test)
-
-if __name__=='__main__':
-    unittest.main(defaultTest='test_suite')

--- a/src/zope/traversing/tests/test_namespacetrversal.py
+++ b/src/zope/traversing/tests/test_namespacetrversal.py
@@ -14,12 +14,110 @@
 """Traversal Namespace Tests
 """
 import re
-from unittest import main
+import unittest
 from doctest import DocTestSuite
+
+from zope import interface
+from zope import component
+from zope.location.interfaces import LocationError
+from zope.traversing import namespace
+
+from zope.component.testing import PlacelessSetup
 from zope.component.testing import setUp, tearDown
 from zope.testing.renormalizing import RENormalizing
 
 
+class TestFunctions(unittest.TestCase):
+
+    def test_getResource_not_found(self):
+        with self.assertRaises(LocationError):
+            namespace.getResource(None, '', None)
+
+
+class TestAcquire(unittest.TestCase):
+
+    def test_excessive_depth_on_path_extension(self):
+        from zope.traversing.interfaces import ITraversable
+        from zope.traversing.namespace import ExcessiveDepth
+
+        @interface.implementer(ITraversable)
+        class Context(object):
+
+            max_call_count = 200
+
+            def traverse(self, name, path):
+                if self.max_call_count:
+                    path.append("I added something")
+                self.max_call_count -= 1
+
+        acq = namespace.acquire(Context(), None)
+        with self.assertRaises(ExcessiveDepth):
+            acq.traverse(None, None)
+
+
+class TestEtc(PlacelessSetup, unittest.TestCase):
+
+    def test_traverse_non_site_name(self):
+        with self.assertRaises(LocationError) as ctx:
+            namespace.etc(None, None).traverse('foobar', ())
+
+        ex = ctx.exception
+        self.assertEqual((None, 'foobar'), ex.args)
+
+    def test_traverse_site_no_manager(self):
+        test = self
+        class Context(object):
+            def __getattribute__(self, name):
+                test.assertEqual(name, 'getSiteManager')
+                return None
+
+        context = Context()
+        with self.assertRaises(LocationError) as ctx:
+            namespace.etc(context, None).traverse('site', ())
+
+        ex = ctx.exception
+        self.assertEqual((context, 'site'), ex.args)
+
+    def test_traverse_site_lookup_error(self):
+        class Context(object):
+            called = False
+            def getSiteManager(self):
+                self.called = True
+                from zope.component import ComponentLookupError
+                raise ComponentLookupError()
+
+        context = Context()
+        with self.assertRaises(LocationError) as ctx:
+            namespace.etc(context, None).traverse('site', ())
+
+        ex = ctx.exception
+        self.assertEqual((context, 'site'), ex.args)
+        self.assertTrue(context.called)
+
+    def test_traverse_utility(self):
+        from zope.traversing.interfaces import IEtcNamespace
+        component.provideUtility(self, provides=IEtcNamespace, name='my etc name')
+
+        result = namespace.etc(None, None).traverse('my etc name', ())
+        self.assertIs(result, self)
+
+
+class TestView(unittest.TestCase):
+
+    def test_not_found(self):
+        with self.assertRaises(LocationError) as ctx:
+            namespace.view(None, None).traverse('name', ())
+
+        ex = ctx.exception
+        self.assertEqual((None, 'name'), ex.args)
+
+
+class TestVh(unittest.TestCase):
+
+    def test_invalid_vh(self):
+        with self.assertRaisesRegexp(ValueError,
+                                     'Vhost directive should have the form'):
+            namespace.vh(None, None).traverse(u'invalid name', ())
 
 def test_suite():
     checker = RENormalizing([
@@ -28,9 +126,9 @@ def test_suite():
          "LocationError"),
     ])
 
-    return DocTestSuite('zope.traversing.namespace',
-                        setUp=setUp, tearDown=tearDown,
-                        checker=checker)
-
-if __name__ == '__main__':
-    main(defaultTest='test_suite')
+    suite = unittest.defaultTestLoader.loadTestsFromName(__name__)
+    suite.addTest(DocTestSuite(
+        'zope.traversing.namespace',
+        setUp=setUp, tearDown=tearDown,
+        checker=checker))
+    return suite

--- a/src/zope/traversing/tests/test_presentation.py
+++ b/src/zope/traversing/tests/test_presentation.py
@@ -13,7 +13,7 @@
 ##############################################################################
 """Presentation Traverser Tests
 """
-from unittest import TestCase, main, makeSuite
+import unittest
 from zope.testing.cleanup import CleanUp
 from zope.interface import Interface, implementer
 from zope.publisher.browser import TestRequest
@@ -38,7 +38,7 @@ class View(object):
         self.content = content
 
 
-class Test(CleanUp, TestCase):
+class Test(CleanUp, unittest.TestCase):
 
     def testView(self):
         browserView(IContent, 'foo', View)
@@ -53,10 +53,3 @@ class Test(CleanUp, TestCase):
         ob = Content()
         r = resource(ob, TestRequest()).traverse('foo', ())
         self.assertEqual(r.__class__, Resource)
-
-
-def test_suite():
-    return makeSuite(Test)
-
-if __name__=='__main__':
-    main(defaultTest='test_suite')

--- a/src/zope/traversing/tests/test_publicationtraverse.py
+++ b/src/zope/traversing/tests/test_publicationtraverse.py
@@ -150,6 +150,9 @@ class TestPublicationTraverser(CleanUp, unittest.TestCase):
         t.traversePath(None, None, 'abc/def///')
 
         # Note that only *one* trailing slash is removed
+        # leaving empty trailing path segments.
+        # This could be considered a bug, although no one has
+        # complained yet.
         self.assertEqual(t.names, ['abc', 'def', '', ''])
 
 
@@ -194,9 +197,11 @@ class TestBeforeTraverseEvent(unittest.TestCase):
         from zope.traversing.interfaces import BeforeTraverseEvent
         from zope.interface.verify import verifyObject
 
-        ob = BeforeTraverseEvent(self, self)
-        self.assertIs(self, ob.request)
-        self.assertIs(self, ob.object)
+        request = object()
+        target = object()
+        ob = BeforeTraverseEvent(target, request)
+        self.assertIs(request, ob.request)
+        self.assertIs(target, ob.object)
         verifyObject(IBeforeTraverseEvent, ob)
 
 class IContent(Interface):

--- a/src/zope/traversing/tests/test_skin.py
+++ b/src/zope/traversing/tests/test_skin.py
@@ -13,7 +13,7 @@
 ##############################################################################
 """Test skin traversal.
 """
-from unittest import TestCase, main, makeSuite
+import unittest
 
 import zope.component
 from zope.testing.cleanup import CleanUp
@@ -29,7 +29,7 @@ class IFoo(Interface):
 directlyProvides(IFoo, IBrowserSkinType)
 
 
-class Test(CleanUp, TestCase):
+class Test(CleanUp, unittest.TestCase):
 
     def setUp(self):
         super(Test, self).setUp()
@@ -52,9 +52,3 @@ class Test(CleanUp, TestCase):
         ob = object()
         traverser = skin(ob, request)
         self.assertRaises(LocationError, traverser.traverse, 'bar', ())
-
-def test_suite():
-    return makeSuite(Test)
-
-if __name__=='__main__':
-    main(defaultTest='test_suite')

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ basepython =
     python2.7
 commands =
     coverage run -m zope.testrunner --test-path=src []
-    coverage report --fail-under=95
+    coverage report --fail-under=100
 deps =
     {[testenv]deps}
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-   py27,py34,py35,py36,pypy,pypy3,coverage
+    py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,20 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy
+envlist =
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
-commands = python setup.py -q test -q
+commands =
+    zope-testrunner --test-path=src []
 deps =
-    six
-    transaction
-    zope.annotation
-    zope.browserresource[zcml]
-    zope.component[zcml]
-    zope.configuration
-    zope.i18n
-    zope.i18nmessageid
-    zope.interface
-    zope.location
-    zope.proxy
-    zope.publisher
-    zope.security[zcml]
-    zope.tales
-    zope.testing
-    zope.testrunner
+    .[test]
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python2.7
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=95
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
Fixes #4 and fixes #6 

Split into two main commits. The usual project gardening (badges, classifiers, etc), and then the additional tests for 100% coverage.