### PR TITLE
Ensure all objects have consistent resolution orders.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ python:
     - 3.8
     - pypy
     - pypy3
-# Not yet, pending https://github.com/zopefoundation/zope.publisher/issues/49
-# env:
-#   global:
-#     - ZOPE_INTERFACE_STRICT_IRO: 1
+env:
+   global:
+     - ZOPE_INTERFACE_STRICT_IRO: 1
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.4.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Ensure all objects have consistent resolution orders. Previously,
+  the "debug" namespace's "errors" flag completely changed the
+  resolution order of the request instead of simply adding the "Debug" skin.
 
 
 4.4.0 (2020-03-30)

--- a/src/zope/traversing/namespace.py
+++ b/src/zope/traversing/namespace.py
@@ -673,7 +673,7 @@ class debug(view):
                 # if we want to enable tracebacks when also trying to
                 # debug a different skin?
                 skin = zope.component.getUtility(IBrowserSkinType, 'Debug')
-                directlyProvides(request, providedBy(request) + skin)
+                directlyProvides(request, skin)
             else:
                 raise ValueError("Unknown debug flag: %s" % flag)
         return self.context

--- a/src/zope/traversing/namespace.py
+++ b/src/zope/traversing/namespace.py
@@ -685,11 +685,9 @@ class debug(view):
             elif flag == 'tal':
                 request.debug.showTAL = True
             elif flag == 'errors':
-                # TODO: I am not sure this is the best solution.  What
-                # if we want to enable tracebacks when also trying to
-                # debug a different skin?
                 # Note that we don't use applySkin(), because it removes all existing
-                # skins.
+                # skins. We may want to get tracebacks while trying to debug a
+                # different skin.
                 debug_skin = zope.component.getUtility(IBrowserSkinType, 'Debug')
                 alsoProvides(request, debug_skin)
             else:

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,8 @@ extras =
     test
 deps =
     coverage
-# Not yet, pending https://github.com/zopefoundation/zope.publisher/issues/49
-# setenv =
-#     ZOPE_INTERFACE_STRICT_IRO=1
+setenv =
+     ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:coverage]
 skip_install = true


### PR DESCRIPTION
Fixes an error where the debug namespace would re-declare everything the request already provided in a bad order.