### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-5.2 (unreleased)
+6.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-02-14)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ TESTS_REQUIRE = [
 
 setup(
     name='zope.traversing',
-    version='5.2.dev0',
+    version='6.0.dev0',
     url='https://github.com/zopefoundation/zope.traversing',
     license='ZPL-2.1',
     author='Zope Foundation and Contributors',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@
 """Setup for zope.traversing package
 """
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -41,7 +40,7 @@ TESTS_REQUIRE = [
     'zope.security[zcml]>=3.8',
     'zope.tales',
     'zope.testing',
-    'zope.testrunner'
+    'zope.testrunner >= 6.4'
 ]
 
 setup(
@@ -72,9 +71,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',
     ],
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     extras_require={
         'test': TESTS_REQUIRE,
         'docs': [

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
